### PR TITLE
04a movementpx

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,25 @@ import React, { Component } from 'react';
 import Dopefish from './Dopefish.js';
 
 class App extends Component {
+  // get viewport width/height dimensions, will handle resizing, from http://stackoverflow.com/questions/36862334/get-viewport-window-height-in-reactjs
+  constructor(props) {
+    super(props);
+    this.state = { width: '0', height: '0' };
+    this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
+  }
+
+  componentDidMount() {
+    this.updateWindowDimensions();
+    window.addEventListener('resize', this.updateWindowDimensions);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateWindowDimensions);
+  }
+
+  updateWindowDimensions() {
+    this.setState({ width: window.innerWidth, height: window.innerHeight });
+  }
   render() {
     return (
       <div className="ft-basis">

--- a/src/App.js
+++ b/src/App.js
@@ -25,9 +25,9 @@ class App extends Component {
   render() {
     return (
       <div className="ft-basis">
-        <Dopefish />
-        <Dopefish />
-        <Dopefish />
+        <Dopefish windowWidth={this.state.width} windowHeight={this.state.height} />
+        <Dopefish windowWidth={this.state.width} windowHeight={this.state.height} />
+        <Dopefish windowWidth={this.state.width} windowHeight={this.state.height} />
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ class App extends Component {
   updateWindowDimensions() {
     this.setState({ width: window.innerWidth, height: window.innerHeight });
   }
+
   render() {
     return (
       <div className="ft-basis">

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -12,12 +12,12 @@ class Dopefish extends Component {
   constructor(props) {
      super(props);
     //  this.handleClick = this.handleClick.bind(this);
-     this.handleClick = _.debounce(this.handleClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
+     this.handleFishClick = _.debounce(this.handleFishClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
      this.state = {
-       posX: this.getRandomIntInclusive(0,this.props.windowWidth),
-       posY: this.getRandomIntInclusive(0,this.props.windowHeight),
-       targetX: this.getRandomIntInclusive(0,this.props.windowWidth),
-       targetY: this.getRandomIntInclusive(0,this.props.windowHeight),
+       posX: this.getRandomIntInclusive(0, this.props.windowWidth),
+       posY: this.getRandomIntInclusive(0, this.props.windowHeight),
+       targetX: this.getRandomIntInclusive(0, this.props.windowWidth),
+       targetY: this.getRandomIntInclusive(0, this.props.windowHeight),
        imgUrl: imgBurp,
      };
    }
@@ -26,9 +26,9 @@ class Dopefish extends Component {
     min = Math.ceil(min);
     max = Math.floor(max);
     return Math.floor(Math.random() * (max - min + 1)) + min;
-  } //must return whole integer to work properly
+  } //math function from MDN - must return whole integer to work properly in this app
 
-  handleClick() {
+  handleFishClick() {
     clearInterval(this.timerID);
     this.setState({
       imgUrl: imgBurp
@@ -86,7 +86,7 @@ class Dopefish extends Component {
 
   render() {
     return (
-      <img src={this.state.imgUrl} alt="A swimming fish" onClick={this.handleClick} style={{top: this.state.posY + 'px', left: this.state.posX + 'px'}}/>
+      <img src={this.state.imgUrl} alt="A swimming fish" onClick={this.handleFishClick} style={{top: this.state.posY + 'px', left: this.state.posX + 'px'}}/>
     );
   }
 }

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -12,7 +12,7 @@ class Dopefish extends Component {
   constructor(props) {
      super(props);
     //  this.handleClick = this.handleClick.bind(this);
-     this.handleClick = _.debounce(this.handleClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation
+     this.handleClick = _.debounce(this.handleClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
      this.state = {
        posX: this.getRandomIntInclusive(0,90),
        posY: this.getRandomIntInclusive(0,90),
@@ -31,7 +31,9 @@ class Dopefish extends Component {
 
   handleClick() {
     clearInterval(this.timerID);
-    this.setState({ imgUrl: imgBurp });
+    this.setState({
+      imgUrl: imgBurp
+    });
     setTimeout(() => {
       this.setMoveInterval(50);
     }, 6000);

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -14,8 +14,8 @@ class Dopefish extends Component {
     //  this.handleClick = this.handleClick.bind(this);
      this.handleFishClick = _.debounce(this.handleFishClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
      this.state = {
-       posX: this.getRandomIntInclusive(0, this.props.windowWidth),
-       posY: this.getRandomIntInclusive(0, this.props.windowHeight),
+       posX: this.getRandomIntInclusive(0, window.innerWidth),
+       posY: this.getRandomIntInclusive(0, window.innerHeight),
        targetX: this.getRandomIntInclusive(0, this.props.windowWidth),
        targetY: this.getRandomIntInclusive(0, this.props.windowHeight),
        imgUrl: imgBurp,

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -14,11 +14,10 @@ class Dopefish extends Component {
     //  this.handleClick = this.handleClick.bind(this);
      this.handleClick = _.debounce(this.handleClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
      this.state = {
-       posX: this.getRandomIntInclusive(0,90),
-       posY: this.getRandomIntInclusive(0,90),
-       targetX: this.getRandomIntInclusive(0,90),
-       targetY: this.getRandomIntInclusive(0,90),
-       increment: 0.25, //while using percent in positioning the element, increment must be able to add to exactly 1 - 0.25 or 0.5 work, 0.4 does not.
+       posX: this.getRandomIntInclusive(0,this.props.windowWidth),
+       posY: this.getRandomIntInclusive(0,this.props.windowHeight),
+       targetX: this.getRandomIntInclusive(0,this.props.windowWidth),
+       targetY: this.getRandomIntInclusive(0,this.props.windowHeight),
        imgUrl: imgBurp,
      };
    }
@@ -35,7 +34,7 @@ class Dopefish extends Component {
       imgUrl: imgBurp
     });
     setTimeout(() => {
-      this.setMoveInterval(50);
+      this.setMoveInterval(20);
     }, 6000);
   }
 
@@ -46,7 +45,7 @@ class Dopefish extends Component {
   }
 
    componentDidMount() {
-     this.setMoveInterval(50);
+     this.setMoveInterval(20);
   }
 
   componentWillUnmount() {
@@ -56,38 +55,38 @@ class Dopefish extends Component {
   tick() {
     if (this.state.posX < this.state.targetX) {
     this.setState((prevState) => ({
-      posX: prevState.posX + prevState.increment,
+      posX: prevState.posX + 1,
       imgUrl: imgRight
     })
     )} else if (this.state.posX > this.state.targetX) {
       this.setState((prevState) => ({
-        posX: prevState.posX - prevState.increment,
+        posX: prevState.posX - 1,
         imgUrl: imgLeft
       })
     )} else {
       this.setState((prevState) => ({
-        targetX: this.getRandomIntInclusive(0,90)
+        targetX: this.getRandomIntInclusive(0,this.props.windowWidth)
       })
     )}
 
     if (this.state.posY < this.state.targetY) {
       this.setState((prevState) => ({
-        posY: prevState.posY + prevState.increment,
+        posY: prevState.posY + 1,
       })
     )} else if (this.state.posY > this.state.targetY) {
       this.setState((prevState) => ({
-        posY: prevState.posY - prevState.increment,
+        posY: prevState.posY - 1,
       })
     )} else {
       this.setState((prevState) => ({
-        targetY: this.getRandomIntInclusive(0,90)
+        targetY: this.getRandomIntInclusive(0,this.props.windowHeight)
       })
     )}
   }
 
   render() {
     return (
-      <img src={this.state.imgUrl} alt="A swimming fish" onClick={this.handleClick} style={{top: this.state.posY + '%', left: this.state.posX + '%'}}/>
+      <img src={this.state.imgUrl} alt="A swimming fish" onClick={this.handleClick} style={{top: this.state.posY + 'px', left: this.state.posX + 'px'}}/>
     );
   }
 }

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -14,10 +14,10 @@ class Dopefish extends Component {
     //  this.handleClick = this.handleClick.bind(this);
      this.handleFishClick = _.debounce(this.handleFishClick.bind(this),6000, { 'leading': true }); //binds, then debounces for duration of animation.
      this.state = {
-       posX: this.getRandomIntInclusive(0, window.innerWidth),
-       posY: this.getRandomIntInclusive(0, window.innerHeight),
-       targetX: this.getRandomIntInclusive(0, this.props.windowWidth),
-       targetY: this.getRandomIntInclusive(0, this.props.windowHeight),
+       posX: this.getRandomIntInclusive(0, window.innerWidth-20),
+       posY: this.getRandomIntInclusive(0, window.innerHeight-20),
+       targetX: this.getRandomIntInclusive(0, this.props.windowWidth-20),
+       targetY: this.getRandomIntInclusive(0, this.props.windowHeight-20),
        imgUrl: imgBurp,
      };
    }
@@ -65,7 +65,7 @@ class Dopefish extends Component {
       })
     )} else {
       this.setState((prevState) => ({
-        targetX: this.getRandomIntInclusive(0,this.props.windowWidth)
+        targetX: this.getRandomIntInclusive(0,this.props.windowWidth-20)
       })
     )}
 
@@ -79,7 +79,7 @@ class Dopefish extends Component {
       })
     )} else {
       this.setState((prevState) => ({
-        targetY: this.getRandomIntInclusive(0,this.props.windowHeight)
+        targetY: this.getRandomIntInclusive(0,this.props.windowHeight-20)
       })
     )}
   }

--- a/src/scss/_index.scss
+++ b/src/scss/_index.scss
@@ -1,3 +1,5 @@
 @import 'vendor/reset';
 @import 'modules/vars';
 @import 'modules/app';
+
+// sass --watch index.scss:../index.css


### PR DESCRIPTION
Fixes #4 - movement is now calculated with px values, not percent. Pixel boundaries (window height/width) are calculated by the `<App />` parent component with an event listener for resize and passed as a prop to each `<Dopefish />`.

Previously, movement speed was fine-tuned by modifying an `interval` value in each Dopefish component's state, where interval was the percentage to change position each tick (which was hardcoded at 50ms between ticks). Now, however, each tick is hardcoded to move 1px at a time and the interval - renamed `tickInterval` determines the number of milliseconds between ticks.  Modifying `tickInterval` will modify movement speed. The default value is 20, for 20ms.

Similarly, with the window height/width values available, position calculations are no longer percent based - each Dopefish component will now take a prop from the parent App container giving windowHeight and windowWidth (which will change if the window is resized, so it can handle resize events automatically) and use these to calculate current x/y position and target position. This could use some testing on high-DPI and low-DPI large monitors to fine-tune the interval in ms, but reducing from 50ms to 20ms is a good enough start.


Technically, this does mean the app will have very odd behavior in a window with dimensions equal to or smaller than 20x20px. :smile:

Unlike percent-based coordinates, the component handles resize by allowing fish to potentially go off-screen to reach a target coordinate set. See #24 for details.