### PR TITLE
Initialpos

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ class App extends Component {
   // get viewport width/height dimensions, will handle resizing, from http://stackoverflow.com/questions/36862334/get-viewport-window-height-in-reactjs
   constructor(props) {
     super(props);
-    this.state = { width: '0', height: '0' };
+    this.state = { width: null, height: null };
     this.updateFishtankDimensions = this.updateFishtankDimensions.bind(this);
     //
   }
@@ -26,9 +26,13 @@ class App extends Component {
   render() {
     return (
       <div className="fishtank" ref="fishtank">
-        <Dopefish width={this.state.width} height={this.state.height} />
-        <Dopefish width={this.state.width} height={this.state.height} />
-        <Dopefish width={this.state.width} height={this.state.height} />
+{ this.state.width && this.state.height &&
+        <div className="fishes">
+          <Dopefish width={this.state.width} height={this.state.height} />
+          <Dopefish width={this.state.width} height={this.state.height} />
+          <Dopefish width={this.state.width} height={this.state.height} />
+        </div>
+}
       </div>
     );
   }

--- a/src/Dopefish.js
+++ b/src/Dopefish.js
@@ -23,8 +23,7 @@ class Dopefish extends Component {
    }
 
   tankBoundariesCalc(val) {
-      let calcval = this.getRandomIntInclusive(0, val)
-      return calcval;
+      return this.getRandomIntInclusive(0, val)
   }
 
   getRandomIntInclusive(min, max) {


### PR DESCRIPTION
Fixes initial position error. Previously, all Dopefish components would always start with state values of `posX: 0, posY: 0` because they made calculations (supposed to be based on height and width props passed in from the parent App component) before the DOM was ready. After the first cycle of pathing to a target x/y and recalculating a new target x/y they worked fine - it was just the initial render that was the problem.

I attempted to use react's lifecycle hooks - specifically componentDidMount() in the Dopefish component to fix this, making it so they'd only set position after the component mounted. 

In the end, it ended up being significantly easier to put a conditional in the parent App component's render statement - it simply refuses to render any Dopefish components until `this.state.height` and `this.state.width` return true (aka have a value) at which point each Dopefish component is rendered with a correctly calculated initial position.

Effectively resolves a lingering behavior problem introduced unintentionally by #23.